### PR TITLE
Path fix for file argument

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -10,7 +10,7 @@ function run_test {
     cd ..
     file=$1
     pathComponents=(${file//// })
-    path_with_dir="devoir-1-tests/tests/${file:2}"
+    path_with_dir="../devoir-1-tests/tests/${file:2}"
     if [ ${pathComponents[1]} = "bonus" ]
     then
         ./gradlew run -q --args="$path_with_dir 1024" > devoir-1-tests/output


### PR DESCRIPTION
If I'm not wrong the devoir-1-tests folder is cloned into our respective devoir folders. The `path_with_dir` needs to go one more folder up for us to be able to directly pass the argument for the file without altering the path ourselves.


` path_with_dir="devoir-1-tests/tests/${file:2}"`
![image](https://github.com/UPB-FILS-ALF/devoir-1-tests/assets/62936850/db4e7882-ac49-41e3-9f9f-b1a89d6f1418)

`path_with_dir="../devoir-1-tests/tests/${file:2}"`
![image](https://github.com/UPB-FILS-ALF/devoir-1-tests/assets/62936850/de582428-1aec-4cb7-bea0-0bfb8f3d4569)
